### PR TITLE
Adding Anvil dupe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ shadowJar {
 }
 
 group = 'online.umbcraft.libraries'
-version = '1.4.0-pre2'
+version = '1.4.0'
 description = 'Golden Dupes - dupes from the Golden days of minecraft!'
 sourceCompatibility = '1.8'
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ shadowJar {
 }
 
 group = 'online.umbcraft.libraries'
-version = '1.4.0-pre1'
+version = '1.4.0-pre2'
 description = 'Golden Dupes - dupes from the Golden days of minecraft!'
 sourceCompatibility = '1.8'
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ shadowJar {
 }
 
 group = 'online.umbcraft.libraries'
-version = '1.3.7'
+version = '1.4.0-pre1'
 description = 'Golden Dupes - dupes from the Golden days of minecraft!'
 sourceCompatibility = '1.8'
 
@@ -36,6 +36,9 @@ processResources {
     from(sourceSets.main.resources.srcDirs) {
         filter ReplaceTokens, tokens: [version: version]
     }
+}
+shadowJar {
+    archiveClassifier = ""
 }
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/online/umbcraft/libraries/GoldenDupes.java
+++ b/src/main/java/online/umbcraft/libraries/GoldenDupes.java
@@ -2,6 +2,7 @@ package online.umbcraft.libraries;
 
 import online.umbcraft.libraries.config.ConfigAutofill;
 import online.umbcraft.libraries.config.ConfigPath;
+import online.umbcraft.libraries.dupes.AnvilDupe;
 import online.umbcraft.libraries.dupes.AutocraftDupe;
 import online.umbcraft.libraries.dupes.DonkeyDupe;
 import online.umbcraft.libraries.dupes.NetherPortalDupe;
@@ -80,6 +81,9 @@ public final class GoldenDupes extends JavaPlugin {
             getServer().getPluginManager().registerEvents(
                     new NetherPortalDupe(this), this);
         }
+
+        getServer().getPluginManager().registerEvents(
+                new AnvilDupe(this), this);
     }
 
 }

--- a/src/main/java/online/umbcraft/libraries/config/ConfigAutofill.java
+++ b/src/main/java/online/umbcraft/libraries/config/ConfigAutofill.java
@@ -19,10 +19,14 @@ public class ConfigAutofill {
         FileConfiguration config = plugin.getConfig();
         int updates = 0;
         for(ConfigPath setting: ConfigPath.values()) {
+            System.out.println("checking setting - "+setting.path());
             if(!config.contains(setting.path())) {
+                System.out.println("\tdoesn't exist: ADDING!");
                 updates++;
                 config.set(setting.path(), setting.value());
             }
+            else
+                System.out.println("\texists");
         }
         if(updates > 0)
             plugin.saveConfig();

--- a/src/main/java/online/umbcraft/libraries/config/ConfigAutofill.java
+++ b/src/main/java/online/umbcraft/libraries/config/ConfigAutofill.java
@@ -18,17 +18,17 @@ public class ConfigAutofill {
 
         FileConfiguration config = plugin.getConfig();
         int updates = 0;
+
         for(ConfigPath setting: ConfigPath.values()) {
-            System.out.println("checking setting - "+setting.path());
-            if(!config.contains(setting.path())) {
-                System.out.println("\tdoesn't exist: ADDING!");
+
+            if(!config.contains(setting.path(), true)) {
                 updates++;
                 config.set(setting.path(), setting.value());
             }
-            else
-                System.out.println("\texists");
         }
-        if(updates > 0)
+        if(updates > 0) {
+            plugin.getConfig().options().copyDefaults(true);
             plugin.saveConfig();
+        }
     }
 }

--- a/src/main/java/online/umbcraft/libraries/config/ConfigPath.java
+++ b/src/main/java/online/umbcraft/libraries/config/ConfigPath.java
@@ -34,6 +34,13 @@ public enum ConfigPath {
     NETHER_TICKDELAY(ConfigRoot.NETHER_PORTAL, "tick-delay", "3"),
 
 
+
+    //      is the donkey dupe enabled?
+    ANVIL_DO(ConfigRoot.ANVIL, "enabled", "true"),
+
+
+
+
     //      should shulker boxes be duped at all?
     NON_STACK_DO_DUPE(ConfigRoot.NON_STACK, "dupe", "true"),
 
@@ -42,13 +49,11 @@ public enum ConfigPath {
 
 
 
-
     //      stack size for duped shulkers
     SHULKERS_DO_DUPE(ConfigRoot.SHULKERS, "dupe", "true"),
 
     //      stack size for duped totems
     SHULKERS_STACKSIZE(ConfigRoot.SHULKERS, "stack-to", "1"),
-
 
 
 

--- a/src/main/java/online/umbcraft/libraries/config/ConfigRoot.java
+++ b/src/main/java/online/umbcraft/libraries/config/ConfigRoot.java
@@ -11,6 +11,10 @@ public enum ConfigRoot {
     // 1.8 nether portal dupe root path
     NETHER_PORTAL("nether-portal"),
 
+    // 1.17 anvil dupe root path
+    ANVIL("anvil-dupe"),
+
+
     //  item limits root path
     NON_STACK("non-stackables"),
 

--- a/src/main/java/online/umbcraft/libraries/dupes/AnvilDupe.java
+++ b/src/main/java/online/umbcraft/libraries/dupes/AnvilDupe.java
@@ -1,44 +1,30 @@
 package online.umbcraft.libraries.dupes;
 
 import online.umbcraft.libraries.GoldenDupes;
-import online.umbcraft.libraries.config.ConfigPath;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.inventory.*;
-import org.bukkit.event.player.PlayerKickEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.*;
 
-public class AnvilDupe implements Listener {
+import static online.umbcraft.libraries.config.ConfigPath.*;
 
-    // super speedy set of all shulker items
-    final private EnumSet<Material> shulkerBoxes;
+public class AnvilDupe implements Listener {
 
     final private GoldenDupes plugin;
 
     public AnvilDupe(final GoldenDupes plugin) {
         this.plugin = plugin;
-
-        // building an EnumSet of all shulkers
-        shulkerBoxes = EnumSet.noneOf(Material.class);
-        Arrays.stream(Material.values())
-                .filter(m -> m.toString().endsWith("SHULKER_BOX"))
-                .forEach(shulkerBoxes::add);
     }
 
-    // gives the player the extra items once they pick up after performing the dupe
+    // gives the player an extra item stack after their anvil breaks w/ a full inventory
     @EventHandler(priority = EventPriority.HIGH)
     public void onAnvilUse(final InventoryClickEvent e) {
         Inventory t = e.getClickedInventory();
@@ -61,11 +47,28 @@ public class AnvilDupe implements Listener {
         // check if anvil was destroyed by next tick
         plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () ->
         {
+
             if (l.getBlock().getType() == Material.AIR) {
+
+                if (
+                        toDupe.getMaxStackSize() == 1 &&
+                                !plugin.getConfig().getBoolean(NON_STACK_DO_DUPE.path())
+                ) return;
+
+                if (
+                        toDupe.getType().name().contains("SHULKER_BOX") &&
+                                !plugin.getConfig().getBoolean(SHULKERS_DO_DUPE.path())
+                ) return;
+
+                if (
+                        toDupe.getType() == Material.TOTEM_OF_UNDYING &&
+                                !plugin.getConfig().getBoolean(TOTEMS_DO_DUPE.path())
+                ) return;
+
                 Item dropped = p.getWorld().dropItem(p.getLocation(),toDupe.clone());
                 dropped.setVelocity(p.getEyeLocation().getDirection());
             }
-        }, 1L);
 
+        }, 1L);
     }
 }

--- a/src/main/java/online/umbcraft/libraries/dupes/AnvilDupe.java
+++ b/src/main/java/online/umbcraft/libraries/dupes/AnvilDupe.java
@@ -1,0 +1,71 @@
+package online.umbcraft.libraries.dupes;
+
+import online.umbcraft.libraries.GoldenDupes;
+import online.umbcraft.libraries.config.ConfigPath;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.inventory.*;
+import org.bukkit.event.player.PlayerKickEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.*;
+
+public class AnvilDupe implements Listener {
+
+    // super speedy set of all shulker items
+    final private EnumSet<Material> shulkerBoxes;
+
+    final private GoldenDupes plugin;
+
+    public AnvilDupe(final GoldenDupes plugin) {
+        this.plugin = plugin;
+
+        // building an EnumSet of all shulkers
+        shulkerBoxes = EnumSet.noneOf(Material.class);
+        Arrays.stream(Material.values())
+                .filter(m -> m.toString().endsWith("SHULKER_BOX"))
+                .forEach(shulkerBoxes::add);
+    }
+
+    // gives the player the extra items once they pick up after performing the dupe
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onAnvilUse(final InventoryClickEvent e) {
+        Inventory t = e.getClickedInventory();
+
+        if (t == null)
+            return;
+        if (t.getType() != InventoryType.ANVIL)
+            return;
+        if(e.getCurrentItem() == null)
+            return;
+
+        if(e.getRawSlot() != 2)
+            return;
+
+        Location l = e.getClickedInventory().getLocation();
+        ItemStack toDupe = e.getCurrentItem();
+        Player p = (Player) e.getWhoClicked();
+
+
+        // check if anvil was destroyed by next tick
+        plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () ->
+        {
+            if (l.getBlock().getType() == Material.AIR) {
+                Item dropped = p.getWorld().dropItem(p.getLocation(),toDupe.clone());
+                dropped.setVelocity(p.getEyeLocation().getDirection());
+            }
+        }, 1L);
+
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -36,9 +36,18 @@ donkey-dupe:
 # 1.8 nether portal minecart dupe
 nether-portal:
 
+  # is this dupe enabled?
   enabled: true
 
+  # how long should the minecart wait before it doesn't dupe items removed from it
   tick-delay: 3
+
+
+# 1.17 anvil dupe
+anvil-dupe:
+
+  # is this dupe enabled?
+  enabled: true
 
 
 ########################
@@ -52,7 +61,7 @@ non-stackables:
 # what is the max duped stack size?
   stack-to: 64
 
-# shulker boxes of any color
+# shulker boxes (of all colors)
 shulkers:
 # can they be duped?
   dupe: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,8 @@
-# GoldenDupes Dupe Plugin #
-#    by Ivan Volkov
-#    @Ivan8or#7412 on discord
+##################################
+#    GoldenDupes Dupe Plugin     #
+#    by Ivan Volkov (Ivan8or)    #
+#    @Ivan8or#7412 on discord    #
+##################################
 
 #  1.12.2 autocraft dupe
 autocraft-dupe:


### PR DESCRIPTION
adding the 1.17 anvil dupe

players must process an item in an anvil, with a full inventory - if the anvil breaks, the item is dropped on the groupd and duplicated