### PR TITLE
Fix 1.12.2 compatibility

### DIFF
--- a/src/main/java/online/umbcraft/libraries/dupes/AnvilDupe.java
+++ b/src/main/java/online/umbcraft/libraries/dupes/AnvilDupe.java
@@ -52,7 +52,7 @@ public class AnvilDupe extends Dupe implements Listener {
             return;
 
         // return if anvil is not about to break
-        if(l.getBlock().getType() != Material.DAMAGED_ANVIL)
+        if(!l.getBlock().getType().name().equals("DAMAGED_ANVIL") || !l.getBlock().getType().name().equals("ANVIL"))
             return;
 
         // preventing the anvil or the block beneath the anvil from being broken / pushed


### PR DESCRIPTION
In 1.12.2, the Material name of anvil is `ANVIL` rather than `DAMAGED_ANVIL`